### PR TITLE
Fix a nil pointer error on a POST with no body and no matching server endpoint

### DIFF
--- a/router.go
+++ b/router.go
@@ -80,7 +80,7 @@ func (ro *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		ro.NotFoundHandler.ServeHTTP(w, r)
 
-		if r.Body == http.NoBody {
+		if r.Body == nil || r.Body == http.NoBody {
 			// do nothing
 		} else {
 			// chew up the rest of the body
@@ -93,12 +93,9 @@ func (ro *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	handler.ServeHTTP(w, r)
 
-	if r.Body == http.NoBody {
+	if r.Body == nil || r.Body == http.NoBody {
 		// do nothing
 	} else {
-		if r.Body == nil {
-			return
-		}
 		// chew up the rest of the body
 		var buf bytes.Buffer
 		buf.ReadFrom(r.Body)


### PR DESCRIPTION
Prevent a POST with no body on a missing endpoint from crashing autoroute

A request with a missing body was causing a nil pointer error
in the case that there was no matching route for the request.